### PR TITLE
fix: don't iterate on messages queue on socket connection; don't send…

### DIFF
--- a/client/jni/tgnet/ConnectionsManager.cpp
+++ b/client/jni/tgnet/ConnectionsManager.cpp
@@ -693,7 +693,7 @@ void ConnectionsManager::onConnectionConnected(Connection *connection) {
             if (networkPaused && lastPauseTime != 0) {
                 lastPauseTime = getCurrentTimeMonotonicMillis();
             }
-            processRequestQueue(connection->getConnectionType(), datacenter->getDatacenterId());
+//            processRequestQueue(connection->getConnectionType(), datacenter->getDatacenterId());
         }
     }
 }

--- a/client/src/main/java/com/attafitamim/mtproto/client/tgnet/ConnectionsManager.java
+++ b/client/src/main/java/com/attafitamim/mtproto/client/tgnet/ConnectionsManager.java
@@ -207,11 +207,11 @@ public class ConnectionsManager {
     }
 
     public <T extends TLObject> int sendRequest(TLMethod<T> method, RequestDelegate<T> completionBlock, int flags, int connetionType) throws Exception {
-        return sendRequest(method, completionBlock, null, null, flags, DEFAULT_DATACENTER_ID, connetionType, true);
+        return sendRequest(method, completionBlock, null, null, flags, DEFAULT_DATACENTER_ID, connetionType, false);
     }
 
     public <T extends TLObject> int sendRequest(TLMethod<T> method, RequestDelegate<T> completionBlock, QuickAckDelegate quickAckBlock, int flags) throws Exception {
-        return sendRequest(method, completionBlock, quickAckBlock, null, flags, DEFAULT_DATACENTER_ID, ConnectionTypeGeneric, true);
+        return sendRequest(method, completionBlock, quickAckBlock, null, flags, DEFAULT_DATACENTER_ID, ConnectionTypeGeneric, false);
     }
 
     public <T extends TLObject> int sendRequest(TLMethod<T> method, final RequestDelegate<T> onComplete, final QuickAckDelegate onQuickAck, final WriteToSocketDelegate onWriteToSocket, final int flags, final int datacenterId, final int connetionType, final boolean immediate) throws Exception {


### PR DESCRIPTION
fix: don't iterate on messages queue on socket connection; don't send immediate requests

This flow leads to duplicating message id.
